### PR TITLE
[bugfix] command line overwritten by build params

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/unity3d/Unity3dBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/unity3d/Unity3dBuilder.java
@@ -158,10 +158,10 @@ public class Unity3dBuilder extends Builder {
            args.add("-projectPath", moduleRootRemote);
         }
         
-        argLine = Util.replaceMacro(argLine, buildVariables);
-        argLine = Util.replaceMacro(argLine, vars);
+        String finalArgLine = Util.replaceMacro(argLine, buildVariables);
+        finalArgLine = Util.replaceMacro(finalArgLine, vars);
         
-        args.add(QuotedStringTokenizer.tokenize(argLine));
+        args.add(QuotedStringTokenizer.tokenize(finalArgLine));
         return args;
     }
 


### PR DESCRIPTION
Fixed a bug that caused the command line to be overwritten by actual
build params if used.
