### PR TITLE
Added a scriptable option for selecting Unity installation

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/unity3d/Unity3dBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/unity3d/Unity3dBuilder/config.jelly
@@ -6,6 +6,9 @@
       </j:forEach>
     </select>
   </f:entry>
+  <f:entry title="${%Scriptable Unity3d installation name}" field="scriptableUnity3dName">
+    <f:textbox />
+  </f:entry>
   <f:entry title="${%Editor command line arguments}" field="argLine">
     <f:textbox />
   </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/unity3d/Unity3dBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/unity3d/Unity3dBuilderTest.java
@@ -54,7 +54,7 @@ public class Unity3dBuilderTest {
     }
 
     private void ensureCreateCommandlineArgs(List<String> expectedArgs1) {
-        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", argLine, "");
+        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", "", argLine, "");
         ArgumentListBuilder commandlineArgs = builder.createCommandlineArgs(exe, moduleRootRemote, new EnvVars(), new Hashtable<String,String>());
         assertEquals(expectedArgs1, commandlineArgs.toList());
     }
@@ -73,7 +73,7 @@ public class Unity3dBuilderTest {
         argLine = "-param1 $param1 -param2 $param2 -projectPath XXXX";
         expectedArgs = asList(exe, "-param1", "value1", "-param2", param2overwrittenValue, "-projectPath", "XXXX");
        
-        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", argLine, "");
+        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", "", argLine, "");
         ArgumentListBuilder commandlineArgs = builder.createCommandlineArgs(exe, moduleRootRemote, vars, buildParameters);
         assertEquals(expectedArgs, commandlineArgs.toList());
         assertEquals("Serialized arg line not modified", argLine, builder.getArgLine());
@@ -90,7 +90,7 @@ public class Unity3dBuilderTest {
         argLine = "-p1 v1 $ARGS";
         expectedArgs = asList(exe, "-p1", "v1", "-projectPath", "XXXX");
 
-        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", argLine, "");
+        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", "", argLine, "");
         ArgumentListBuilder commandlineArgs = builder.createCommandlineArgs(exe, moduleRootRemote, vars, buildParameters);
         assertEquals(expectedArgs, commandlineArgs.toList());
         assertEquals("Serialized arg line not modified", argLine, builder.getArgLine());
@@ -108,11 +108,11 @@ public class Unity3dBuilderTest {
     }
 
     private void ensureUnstableReturnCodesParsingWorks(Integer[] expectedResultCodes, String unstableReturnCodes) throws Exception {
-        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", argLine, unstableReturnCodes);
+        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", "", argLine, unstableReturnCodes);
         assertEquals(new HashSet<Integer>(asList(expectedResultCodes)), builder.toUnstableReturnCodesSet());
     }
     private void ensureUnstableReturnCodesParsingFails(String unstableReturnCodes) {
-        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", argLine, unstableReturnCodes);
+        Unity3dBuilder builder = new Unity3dBuilder("Unity 3.5", "", argLine, unstableReturnCodes);
         try {
             builder.toUnstableReturnCodesSet();
             Assert.fail("Expected failure");


### PR DESCRIPTION
Can use environment and build variables, instead of selecting from a static drop-down box. Should still point to a name in the global Unity3d installations. Standard behaviour until used.